### PR TITLE
Better documentation on running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ A living style guide and documentation for GOV.UK Components &mdash; A new appro
 
 ## Caveats
 
-It's still in it's early stages, many features are missing or incomplete, and documentation may not be 100% accurate. 
+It's still in it's early stages, many features are missing or incomplete, and documentation may not be 100% accurate.
 
-It currently depends on an unreleased version of [Slimmer](https://github.com/alphagov/slimmer), in particular on this [branch](https://github.com/alphagov/slimmer/pull/76/files), as well as a [branch](https://github.com/alphagov/static/pull/430/files) on [Static](https://github.com/alphagov/static).
-
-If you're running those branches of Slimmer and Static locally then you can use this app by setting the `SLIMMER_DEV` environmental variable while running the app.
+It depends on [Slimmer](https://github.com/alphagov/slimmer) and makes API calls to [Static](https://github.com/alphagov/static).
 
 ## Installation
 
@@ -18,7 +16,7 @@ It's a pretty standard Rails app, clone it, `bundle` it.
 
 You'll need to set the environment variable `PLEK_SERVICE_STATIC_URI` to be a host running an instance of [alphagov/static](https://github.com/alphagov/static).
 
-This is where the component documenation used to generate the dynamic parts of this guide is fetched from. Pointing at
+This is where the component documentation used to generate the dynamic parts of this guide is fetched from. Pointing at
 different static hosts may show different components. For example, pointing at `assets.digital.cabinet-office.gov.uk` will
 be the latest/in-production version of components, but you could also point a local/in-development static host, to preview
 it's components (see below)


### PR DESCRIPTION
- In particular against a local instance of static
- We're no longer dependant on a dev/branch version of `slimmer` or `static`, so remove that
