### PR TITLE
Only cache if in Production

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -4,9 +4,13 @@ class Component < Struct.new(:id, :name, :description, :body, :fixtures)
   end
 
   def self.all
-    Rails.cache.fetch('component_doc', expires_in: 15.minute) {
-      fetch_component_doc
-    }.map { |component| build(component) }
+    if Rails.env.production? # Only use caching if we're in Production
+      Rails.cache.fetch('component_doc', expires_in: 15.minute) {
+        fetch_component_doc
+      }.map { |component| build(component) }
+    else
+      fetch_component_doc.map { |component| build(component) }
+    end
   end
 
   def self.build(component)


### PR DESCRIPTION
When adding or updating the docs in development, the caching means that you need to restart the App to get the updated version. This commit moves the caching to only happen in Production.
