### PR TITLE
Fix example code

### DIFF
--- a/app/models/fixture.rb
+++ b/app/models/fixture.rb
@@ -4,7 +4,7 @@ class Fixture < Struct.new(:id, :data)
   end
 
   def pretty_data
-    JSON.pretty_generate(data).gsub('\\n', "\n    ").strip
+    JSON.pretty_generate(data).gsub('\\n', "\n    ").gsub(/":/, '" =>').strip
   end
 
   def data?


### PR DESCRIPTION
JSON.pretty_generate returns JSON which isn't valid Ruby and can't be used to pass locals into a partial. This commit adds a gsub to generate correct Ruby hashes using the `"key" => value` syntax.
