### PR TITLE
About page presentation tidy up

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@
 div.code-block {
   @extend %outdent-to-full-width;
   padding: $gutter;
+  margin:30px 0;
   // Match Prism styles to avoid a flash as it renders
   background: #f5f2f0;
   font-family: Consolas, Monaco, 'Andale Mono', monospace;
@@ -48,6 +49,11 @@ div.code-block {
     @include bold-36;
     margin: $gutter 0;
   }
+
+  p {
+    @include core-19;
+    max-width:740px;
+  }
 }
 
 #header {
@@ -71,3 +77,13 @@ div.code-block {
   }
 }
 
+.about-components {
+  h2 {
+    @include bold-24;
+    margin:30px 0 20px 0;
+  }
+
+  p {
+    margin-bottom: 20px;
+  }
+}

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -2,22 +2,26 @@
   About
 <% end %>
 
-<h2>What's a component?</h2>
+<div class="about-components">
 
-<p>A simple way to share UI patterns between applications without having to duplicate code</p>
+  <h2>What's a component?</h2>
 
-<p>Components hook in to your application template path and will allow you to insert a partial, which will handle it's own markup and styling.</p>
+  <p>A simple way to share UI patterns between applications without having to duplicate code</p>
 
-<p>You can can consider them an abstraction/blackbox around a piece of UI, where you don't want to care about how it works, just that it does.</p>
+  <p>Components hook in to your application template path and will allow you to insert a partial, which will handle it's own markup and styling.</p>
 
-<h2>How do I use one?</h2>
+  <p>You can can consider them an abstraction/blackbox around a piece of UI, where you don't want to care about how it works, just that it does.</p>
 
-<p>You need to be using <a href="https://github.com/alphagov/slimmer" rel="external">Slimmer</a> in your Rails app, and add <code>include Slimmer::SharedTemplates</code> to your <code>ApplicationController</code>.</p>
+  <h2>How do I use one?</h2>
 
-<p>From a template call a partial scoped to <code>govuk_component/</code> followed by the component name (<a href="/component">available components</a>).</p>
+  <p>You need to be using <a href="https://github.com/alphagov/slimmer" rel="external">Slimmer</a> in your Rails app, and add <code>include Slimmer::SharedTemplates</code> to your <code>ApplicationController</code>.</p>
 
-<div class="code-block">
-  <code class="language-ruby">&lt;%= render partial: 'govuk_component/example_component' %&gt;</code>
+  <p>From a template call a partial scoped to <code>govuk_component/</code> followed by the component name (<a href="/component">available components</a>).</p>
+
+  <div class="code-block">
+    <code class="language-ruby">&lt;%= render partial: 'govuk_component/example_component' %&gt;</code>
+  </div>
+
+  <p>This is still a huge work in progress, but this guide is intended expose that work as early and widely as possible. Lots of feedback welcome to <a href="https://github.com/dsingleton/" rel="external">David</a> and <a href="https://github.com/edds" rel="external">Edd</a>.</p>
+
 </div>
-
-<p>This is still a huge work in progress, but this guide is intended expose that work as early and widely as possible. Lots of feedback welcome to <a href="https://github.com/dsingleton/" rel="external">David</a> and <a href="https://github.com/edds" rel="external">Edd</a>.</p>


### PR DESCRIPTION
While looking into how to make components, I thought I'd clean up the about page to:

- Add some type hierarchy.
- Use shorter line lengths

Going from this:

![screenshot_606](https://cloud.githubusercontent.com/assets/265403/5978198/0c193134-a896-11e4-886a-7b1547781375.png)

To this:

![screenshot_605](https://cloud.githubusercontent.com/assets/265403/5978203/14e34ee4-a896-11e4-98f1-0dcaeffe5763.png)

