### PR TITLE
Fix broken controller tests and use Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GOV.UK Component Guide
 
+[![Build Status](https://travis-ci.org/alphagov/govuk-component-guide.svg)](https://travis-ci.org/alphagov/govuk-component-guide)
+
 A living style guide and documentation for GOV.UK Components &mdash; A new approach to sharing UI patterns between applications without having to duplicate code.
 
 ## Caveats

--- a/test/controllers/component_controller_test.rb
+++ b/test/controllers/component_controller_test.rb
@@ -1,8 +1,13 @@
 require 'test_helper'
 
 class ComponentControllerTest < ActionController::TestCase
+  test "should get list" do
+    get :list
+    assert_response :success
+  end
+
   test "should get show" do
-    get :show
+    get :show, id: 'title'
     assert_response :success
   end
 


### PR DESCRIPTION
Show wasn't sending an `id` param, so didn't match a route.

In the future this should fixture the component doc data from static,
to avoid network calls in tests. But for now get things working again.

I've also setup a job on travis so we should _see_ when tests are failing
as part of the normal dev/PR process.