### PR TITLE
Correct locals syntax in docs

### DIFF
--- a/app/models/fixture.rb
+++ b/app/models/fixture.rb
@@ -4,7 +4,7 @@ class Fixture < Struct.new(:id, :data)
   end
 
   def pretty_data
-    JSON.pretty_generate(data).gsub('\\n', "\n    ").gsub(/":/, '" =>').strip
+    JSON.pretty_generate(data).gsub('\\n', "\n    ").gsub(/"(\w*)":/, '\1:').strip
   end
 
   def data?


### PR DESCRIPTION
This commit uses the new ruby hash syntax for the docs, allowing easier
copying and pasting of code.