### PR TITLE
Stop CSS from overriding examples

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,15 +45,11 @@ div.code-block {
   @extend %site-width-container;
   padding-bottom: $gutter * 4;
 
-  > h1 {
+  h1 {
     @include bold-36;
     margin: $gutter 0;
   }
 
-  p {
-    @include core-19;
-    max-width:740px;
-  }
 }
 
 #header {
@@ -67,6 +63,13 @@ div.code-block {
 
   .app-name {
     margin: 0
+  }
+}
+
+#content {
+  p {
+    @include core-19;
+    max-width: $two-thirds;
   }
 }
 

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -2,7 +2,7 @@
   About
 <% end %>
 
-<div class="about-components">
+<div class="about-components" id="content">
 
   <h2>What's a component?</h2>
 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -2,7 +2,9 @@
   Home
 <% end %>
 
-<p>Components are a way to share UI patterns between applications, without duplicating code. <a href="/about">Find out more</a></p>
+<div id="content">
+  <p>Components are a way to share UI patterns between applications, without duplicating code. <a href="/about">Find out more</a></p>
 
-<h1>Components</h1>
-<%= render partial: "component/list", locals: {components: @components } %>
+  <h1>Components</h1>
+  <%= render partial: "component/list", locals: {components: @components } %>
+</div>


### PR DESCRIPTION
Because the CSS declaration was very specific it was overriding the example CSS (in the case of the beta banner setting the font-size and max-width).