### PR TITLE
Fix 'superclass mismatch for class Component' error

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -1,4 +1,4 @@
-class Component < Struct.new(:id, :name, :description, :body, :fixtures)
+Component = Struct.new(:id, :name, :description, :body, :fixtures) do
   def self.get(id)
     all.select { |component| component.id == id }.first
   end

--- a/app/models/fixture.rb
+++ b/app/models/fixture.rb
@@ -1,4 +1,4 @@
-class Fixture < Struct.new(:id, :data)
+Fixture = Struct.new(:id, :data) do
   def name
     id.humanize
   end


### PR DESCRIPTION
Inheriting from `Struct` was causing errors in dev (but nor prod)
presumably due to Rails class reloading (at a guess).

More generally it's recommended not to inherit from `Struct`, see:
- http://www.benjaminoakes.com/2013/10/15/superclass-mismatch-when-inheriting-from-struct-new/