### PR TITLE
Better error handling and debugger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,25 +8,11 @@ gem 'sass-rails', '~> 4.0.3'
 gem 'uglifier', '>= 1.3.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
+
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0',        group: :doc
 
 gem 'kramdown', '1.5'
-
-# Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-gem 'spring',      group: :development
-
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use unicorn as the app server
-# gem 'unicorn'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
-
-# Use debugger
-# gem 'debugger', group: [:development, :test]
 
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
@@ -36,3 +22,10 @@ end
 
 gem 'govuk_frontend_toolkit', '2.0.0'
 gem 'rest-client'
+
+group :development do
+  gem 'spring'
+  gem 'pry'
+  gem 'better_errors'
+  gem 'binding_of_caller'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,15 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
     arel (5.0.1.20140414130214)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     builder (3.2.2)
+    coderay (1.1.0)
+    debug_inspector (0.0.2)
     erubis (2.7.0)
     execjs (2.2.1)
     govuk_frontend_toolkit (2.0.0)
@@ -44,6 +52,7 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.2)
     minitest (5.4.0)
@@ -54,6 +63,10 @@ GEM
     null_logger (0.0.1)
     plek (1.10.0)
     polyglot (0.3.5)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -95,6 +108,7 @@ GEM
       plek (>= 1.1.0)
       rack (>= 1.3.5)
       rest-client
+    slop (3.6.0)
     spring (1.1.3)
     sprockets (2.11.0)
       hike (~> 1.2)
@@ -121,9 +135,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   govuk_frontend_toolkit (= 2.0.0)
   jbuilder (~> 2.0)
   kramdown (= 1.5)
+  pry
   rails (= 4.1.4)
   rest-client
   sass-rails (~> 4.0.3)
@@ -131,3 +148,6 @@ DEPENDENCIES
   slimmer (= 8.1.0)
   spring
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.10.3


### PR DESCRIPTION
Add `pry` for console debugging and `better_errors` +
`binding_of_caller` for debugging errors within the browser.

We use these on most of our other apps and they're very useful.