### PR TITLE
Only support symbol keys for fixure hashes

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -14,10 +14,10 @@ Component = Struct.new(:id, :name, :description, :body, :fixtures) do
   end
 
   def self.build(component)
-    fixtures = component["fixtures"].map {|id, data|
-      Fixture.new(id, data.with_indifferent_access)
+    fixtures = component[:fixtures].map {|id, data|
+      Fixture.new(id.to_s, data)
     }
-    self.new(component["id"], component["name"], component["description"], component["body"], fixtures)
+    self.new(component[:id], component[:name], component[:description], component[:body], fixtures)
   end
 
   def self.component_doc_url
@@ -25,7 +25,10 @@ Component = Struct.new(:id, :name, :description, :body, :fixtures) do
   end
 
   def self.fetch_component_doc
-    JSON.parse(RestClient.get(component_doc_url).body)
+    JSON.parse(
+      RestClient.get(component_doc_url).body,
+      {symbolize_names: true}
+    )
   end
 
   def fixture


### PR DESCRIPTION

- [x] 1. [Update static components to support either strings or symbols](https://github.com/alphagov/static/pull/601)
- [x] 2. Update [clients that call components with strings](https://github.com/search?utf8=%E2%9C%93&q=govuk_component%2Foption_select+OR+govuk_component%2Fprevious_and_next_navigation+repo%3Aalphagov%2Fcalendars+repo%3Aalphagov%2Fcollections+repo%3Aalphagov%2Fdesign-principles+repo%3Aalphagov%2Ffeedback+repo%3Aalphagov%2Fcourts-frontend+repo%3Aalphagov%2Fcalculators+repo%3Aalphagov%2Flicence-finder+repo%3Aalphagov%2Ffrontend+repo%3Aalphagov%2Fgovernment-frontend+repo%3Aalphagov%2Fsmart-answers+repo%3Aalphagov%2Finfo-frontend+repo%3Aalphagov%2Fcontacts-frontend+repo%3Aalphagov%2Fmanuals-frontend+repo%3Aalphagov%2Fspecialist-frontend+repo%3Aalphagov%2Ffinder-frontend+repo%3Aalphagov%2Fbusiness-support-finder+repo%3Aalphagov%2Fwhitehall+repo%3Aalphagov%2Fstatic&type=Code&ref=searchresults) to use symbols ([finder-frontend](https://github.com/alphagov/finder-frontend/pull/217) and [manuals-frontend](https://github.com/alphagov/manuals-frontend/pull/147))
- [ ] 3. [Update static to only support symbols](https://github.com/alphagov/static/pull/602)

This PR can be merged after 1. otherwise it will break the previewing 
of the components using string keys.

--

Some components templates in static use symbol keys and some use
strings, which is inconsistent and confusing, this helps us
standardise on symbols, by only supporting symbol in guide fixtures.

However the copy/pastable example for a fixture all use symbol keys,
meaning that copy/pasting them into an app would not work if the
component on static used symbols.

Previously the difference was masked with `with_indifferent_access`,
allowing both types of keys. Only using symbols means any component
trying to access an object by string key will not display the right
data for that key. This should be more obvious to someone checking
the component within the guide.

Longer term we might want to add testing that would also catch this,
but for now we can rely on component changes being tested against
the guide and key problems spotted.