### PR TITLE
Use Ruby from .ruby-version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby File.read('.ruby-version').strip
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.4'
 # Use SCSS for stylesheets


### PR DESCRIPTION
The analytics_meta_tag component calls `Hash#to_h` which doesn't exist before Ruby 2. This was running under 1.9.3 on Heroku so we need to make it obey the `.ruby-version` there.

/cc @dsingleton 