### PR TITLE
Raise helpful error if static  docs can't be fetched

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -25,10 +25,14 @@ Component = Struct.new(:id, :name, :description, :body, :fixtures) do
   end
 
   def self.fetch_component_doc
-    JSON.parse(
-      RestClient.get(component_doc_url).body,
-      {symbolize_names: true}
-    )
+    begin
+      JSON.parse(
+        RestClient.get(component_doc_url).body,
+        {symbolize_names: true}
+      )
+    rescue RestClient::BadGateway => e
+      raise "#{e} from #{Plek.current.find('static')} - is static running?"
+    end
   end
 
   def fixture


### PR DESCRIPTION
Before this gave a stack trace deep in `RestClient`, without application
context, which isn't clear what the problem actually was.

Raise a more explicit error message that makes it clear that static couldn't
be reached, and show which instance of static the application was trying to
fetch from, as a common case is not having overridden the `Plek` ENV var

Note: This code needs moving out of a model and into a lib/helper in the future
but for now just make the error more useful.