### PR TITLE
Rename `.preview` to avoid clashes with component

### DIFF
--- a/app/assets/stylesheets/_component.scss
+++ b/app/assets/stylesheets/_component.scss
@@ -8,7 +8,7 @@ div.component-show {
     margin: $gutter 0;
   }
 
-  .preview {
+  .component-guide-preview {
     @extend %outdent-to-full-width;
     padding: $gutter;
 
@@ -50,7 +50,7 @@ div.component-show {
           }
         }
 
-        >.preview {
+        >.component-guide-preview {
           margin-top: $gutter/2;
           margin-bottom: $gutter/2;
         }

--- a/app/assets/stylesheets/preview.css.scss
+++ b/app/assets/stylesheets/preview.css.scss
@@ -20,7 +20,7 @@ body.hide-header-and-footer {
   min-height: 8em;
 }
 
-.preview {
+.component-guide-preview {
   padding: 30px 0;
   > h2 {
     margin-bottom: 1em;

--- a/app/views/components/_preview.html.erb
+++ b/app/views/components/_preview.html.erb
@@ -1,3 +1,3 @@
-<div class="preview">
+<div class="component-guide-preview">
   <%= render partial: "govuk_component/#{component.id}", locals: fixture.data %>
 </div>

--- a/app/views/components/preview.html
+++ b/app/views/components/preview.html
@@ -3,7 +3,7 @@
 <% end %>
 
 <% @component.fixtures.each do |fixture| %>
-<div class="preview">
+<div class="component-guide-preview">
   <h2><a href="<%= component_fixture_path(@component.id, fixture.id) %>"><%= fixture.name %></a></h2>
   <%= render partial: "govuk_component/#{@component.id}", locals: fixture.data %>
 </div>

--- a/app/views/fixtures/preview.html.erb
+++ b/app/views/fixtures/preview.html.erb
@@ -2,6 +2,6 @@
   <%= @component.name %>: <%= @fixture.name %> preview
 <% end %>
 
-<div class="preview">
+<div class="component-guide-preview">
   <%= render partial: "govuk_component/#{@component.id}", locals: @fixture.data %>
 </div>


### PR DESCRIPTION
Adding attachment HTML to the govspeak component includes examples
of `preview` as a class name, which was being overridden by the
component guide styling.

This has come up a few times with the component guide ([eg](https://github.com/alphagov/govuk-component-guide/pull/16)), and we need
a better long term fix, but for now this fixes the attachment examples
i'm working on.

Longer term fixes might include;
 - using a BEM like approach in components, to avoid class name clashes
 - using BEM in the component guide and avoiding element level selectors
   entirely.