### PR TITLE
Refactor guide SCSS to not override components

### DIFF
--- a/app/assets/stylesheets/_component.scss
+++ b/app/assets/stylesheets/_component.scss
@@ -1,13 +1,20 @@
 .component-show {
 
   .component-doc {
-    .description {
-      @include core-24;
-    }
+    @include core-16;
 
     p {
-      @include core-19;
-      margin: $gutter 0;
+      margin: $gutter-half 0;
+    }
+
+    ol,
+    ul {
+      margin: 0 0 0 $gutter;
+    }
+
+    h3 {
+      margin: $gutter 0 $gutter-half;
+      @include bold-19;
     }
   }
 

--- a/app/assets/stylesheets/_component.scss
+++ b/app/assets/stylesheets/_component.scss
@@ -1,11 +1,14 @@
 .component-show {
-  .description {
-    @include core-24;
-  }
 
-  > p {
-    @include core-19;
-    margin: $gutter 0;
+  .component-doc {
+    .description {
+      @include core-24;
+    }
+
+    p {
+      @include core-19;
+      margin: $gutter 0;
+    }
   }
 
   .component-guide-preview {
@@ -26,7 +29,7 @@
   .fixtures {
     margin-top: $gutter * 2;
 
-    >h2 {
+    .fixtures-title {
       @include bold-27;
       margin: $gutter 0;
 
@@ -35,27 +38,15 @@
       }
     }
 
-    >ol {
-      margin: 0;
-      padding: 0;
-      list-style: none;
+    .component-fixture {
+      margin: 0 0 $gutter * 2;
 
-      .fixture {
-        margin: 0 0 $gutter * 2;
+      .fixture-title {
+        @include bold-24;
+        margin: $gutter-half 0;
 
-        >h3 {
-          @include bold-24;
-          margin: $gutter-half 0;
-
-          // scss-lint:disable NestingDepth
-          small {
-            @include bold-16;
-          }
-        }
-
-        >.component-guide-preview {
-          margin-top: $gutter / 2;
-          margin-bottom: $gutter / 2;
+        small {
+          @include bold-16;
         }
       }
     }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,18 +38,22 @@ $border-color: #ccc;
 
 #wrapper {
   padding-bottom: $gutter * 4;
+}
+// scss-lint:enable IdSelector
 
-  > h1 {
-    @include bold-36;
-    margin: $gutter 0;
-  }
+.govuk-component-guide-title {
+  @include bold-36;
+  margin: $gutter 0;
+}
+
+.govuk-component-guide-title-description {
+  margin-bottom: $gutter;
 
   p {
     @include core-19;
     max-width: 740px;
   }
 }
-// scss-lint:enable IdSelector
 
 .govuk-component-guide-header {
   @include core-19;

--- a/app/assets/stylesheets/preview.css.scss
+++ b/app/assets/stylesheets/preview.css.scss
@@ -20,11 +20,11 @@ html {
 .component-guide-preview {
   padding: 30px 0;
 
-  > h2 {
+  .preview-title {
     margin-bottom: 1em;
     @include bold-16;
 
-    > a {
+    a {
       color: $black;
     }
   }

--- a/app/views/components/preview.html
+++ b/app/views/components/preview.html
@@ -4,7 +4,7 @@
 
 <% @component.fixtures.each do |fixture| %>
 <div class="component-guide-preview">
-  <h2><a href="<%= component_fixture_path(@component.id, fixture.id) %>"><%= fixture.name %></a></h2>
+  <h2 class="preview-title"><a href="<%= component_fixture_path(@component.id, fixture.id) %>"><%= fixture.name %></a></h2>
   <%= render partial: "govuk_component/#{@component.id}", locals: fixture.data %>
 </div>
 <% end %>

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -3,36 +3,40 @@
 <% end %>
 
 <div class="component-show">
-  <p class="description"><%= @component.description %></p>
+  <div class="component-doc">
+    <p class="description"><%= @component.description %></p>
 
-  <% if @component.body %>
-    <%= @component.html_body %>
-  <% end %>
+    <div class="body">
+      <% if @component.body %>
+        <%= @component.html_body %>
+      <% end %>
+    </div>
 
-  <p>How to call this component</p>
-  <%= render partial: "components/call", locals: { component: @component, fixture: @component.fixture } %>
+    <p>How to call this component</p>
+    <%= render partial: "components/call", locals: { component: @component, fixture: @component.fixture } %>
 
-  <p>How this component looks</p>
+    <p>How this component looks</p>
+  </div>
+
   <%= render partial: "components/preview", locals: { component: @component, fixture: @component.fixture } %>
 
   <% if @component.other_fixtures.any? %>
-  <div class="fixtures">
-    <h2>Other examples <small>(<a href="<%= component_preview_path(@component.id) %>">preview all</a>)</small></h2>
-    <ol>
-    <% @component.other_fixtures.each do |fixture| %>
-      <li class="fixture">
-        <h3>
-          <a href="<%= component_fixture_path(@component.id, fixture.id) %>"><%= fixture.name %></a>
-          <small>(<a href="<%= component_fixture_preview_path(@component.id, fixture.id) %>">preview</a>)</small>
-        </h3>
+    <div class="fixtures">
+      <h2 class="fixtures-title">Other examples <small>(<a href="<%= component_preview_path(@component.id) %>">preview all</a>)</small></h2>
 
-        <%= render partial: "components/call", locals: { component: @component, fixture: fixture } %>
+      <% @component.other_fixtures.each do |fixture| %>
+        <div class="component-fixture">
+          <h3 class="fixture-title">
+            <a href="<%= component_fixture_path(@component.id, fixture.id) %>"><%= fixture.name %></a>
+            <small>(<a href="<%= component_fixture_preview_path(@component.id, fixture.id) %>">preview</a>)</small>
+          </h3>
 
-        <%= render partial: "components/preview", locals: { component: @component, fixture: fixture } %>
-      </li>
-    <% end %>
-    </ol>
-  </div>
+          <%= render partial: "components/call", locals: { component: @component, fixture: fixture } %>
+
+          <%= render partial: "components/preview", locals: { component: @component, fixture: fixture } %>
+        </div>
+      <% end %>
+    </div>
   <% end %>
 
 </div>

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -2,20 +2,20 @@
   <%= @component.name %>
 <% end %>
 
+<% content_for :header_description do %>
+  <p><%= @component.description %></p>
+<% end %>
+
 <div class="component-show">
   <div class="component-doc">
-    <p class="description"><%= @component.description %></p>
+    <% if @component.body %>
+      <%= @component.html_body %>
+    <% end %>
 
-    <div class="body">
-      <% if @component.body %>
-        <%= @component.html_body %>
-      <% end %>
-    </div>
-
-    <p>How to call this component</p>
+    <h3>How to call this component</h3>
     <%= render partial: "components/call", locals: { component: @component, fixture: @component.fixture } %>
 
-    <p>How this component looks</p>
+    <h3>How this component looks</h3>
   </div>
 
   <%= render partial: "components/preview", locals: { component: @component, fixture: @component.fixture } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,10 @@
     <p class="app-name"><a href="/">GOV.UK Components Guide</a></p>
   </div>
 
-  <h1><%= yield :header %></h1>
+  <h1 class="govuk-component-guide-title"><%= yield :header %></h1>
+  <% if content_for?(:header_description) %>
+  <div class="govuk-component-guide-title-description"><%= yield :header_description %></div>
+  <% end %>
 
   <%= yield %>
 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -2,7 +2,8 @@
   Home
 <% end %>
 
-<p>Components are a way to share UI patterns between applications, without duplicating code. <a href="/about">Find out more</a></p>
+<% content_for :header_description do %>
+  <p>Components are a way to share UI patterns between applications, without duplicating code. <a href="/about">Find out more</a></p>
+<% end %>
 
-<h1>Components</h1>
 <%= render partial: "components/list", locals: {components: @components } %>


### PR DESCRIPTION
To avoid overriding component styles. Previously we'd used lots of
direct descendant selectors, `>`, which is hard to read and a little
brittle.

Re-write those pages to use a BEM-esq syntax, avoiding element selectors
and using component guide specific selectors, these will only override
component styles if a component used a class like `fixtures-title`,
which is possible, but far more likely

i'm not a huge fan/convinced of the BEM-esq approach, but it's an improvement
over the leaking of styles that we did have. I'd like to revist this somewhen, but
for now it feels like an improvement, and fixes some rendering bugs in the guide.