### PR TITLE
Improve code block styling.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,8 @@ $border-color: #ccc;
   margin: 30px 0;
   padding: $gutter;
   @extend %outdent-to-full-width;
+  overflow: scroll;
+  max-height: 300px;
 
   // Match Prism styles to avoid a flash as it renders
   background: $prism-background;


### PR DESCRIPTION
This fixes text escaping the code blocks, and also makes them a bit shorter.

Before:

![screen shot 2016-03-16 at 17 20 49](https://cloud.githubusercontent.com/assets/1650875/13822256/d621962a-eb9c-11e5-986d-b4f96b48907f.png)

After:

![screen shot 2016-03-16 at 17 20 59](https://cloud.githubusercontent.com/assets/1650875/13822258/d6fabf18-eb9c-11e5-8652-f984b81467a7.png)
