### PR TITLE
Update the govuk frontend toolkit to 4.10.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ else
   gem 'slimmer', '9.1.0'
 end
 
-gem 'govuk_frontend_toolkit', '2.0.0'
+gem 'govuk_frontend_toolkit', '4.10.0'
 gem 'rest-client'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     govuk-lint (0.7.0)
       rubocop (~> 0.35.0)
       scss_lint (~> 0.44.0)
-    govuk_frontend_toolkit (2.0.0)
+    govuk_frontend_toolkit (4.10.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     http-cookie (1.0.2)
@@ -185,7 +185,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   govuk-lint (= 0.7.0)
-  govuk_frontend_toolkit (= 2.0.0)
+  govuk_frontend_toolkit (= 4.10.0)
   jbuilder (~> 2.0)
   kramdown (= 1.5)
   pry


### PR DESCRIPTION
In attempting to update the appearance of the phase banner, which doesn’t
appear to be changed here:
http://govuk-component-guide.herokuapp.com/components/alpha_label.

I’m also updating the govuk front end toolkit here to the latest version, as
release v4.9.1 includes this fix.