### PR TITLE
Display govuk header, with service-style title

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,9 +31,6 @@ $border-color: #ccc;
 }
 
 // scss-lint:disable IdSelector
-#global-header,
-#global-header-bar,
-#global-breadcrumb,
 #footer {
   display: none;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,6 @@ class ApplicationController < ActionController::Base
 private
 
   def set_custom_slimmer_headers
-    set_slimmer_headers(report_a_problem: 'false')
+    set_slimmer_headers(report_a_problem: 'false', remove_search: true)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,11 +9,15 @@
 </head>
 <body>
 
-<div id="wrapper">
-
-  <div class="govuk-component-guide-header">
-    <p class="app-name"><a href="/">GOV.UK Components Guide</a></p>
+<div class="header-proposition">
+  <div class="content">
+    <nav id="proposition-menu" role="navigation">
+      <a href="/" id="proposition-name">GOV.UK Publishing Component Guide</a>
+    </nav>
   </div>
+</div>
+
+<div id="wrapper">
 
   <h1 class="govuk-component-guide-title"><%= yield :header %></h1>
   <% if content_for?(:header_description) %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for :header do %>
-  Home
+  GOV.UK Publishing Component Guide
 <% end %>
 
 <% content_for :header_description do %>
-  <p>Components are a way to share UI patterns between applications, without duplicating code. <a href="/about">Find out more</a></p>
+  <p>Components are a way to share UI patterns between applications, without duplicating code, within the GOV.UK Publishing platform. <a href="/about">Find out more</a></p>
 <% end %>
 
 <%= render partial: "components/list", locals: {components: @components } %>


### PR DESCRIPTION
Adds GOV.UK branding the component guide. This is the same approach `govuk-elements`
takes, rather than completely removing all branding.

This still has issues with displaying , due to conflicting
IDs / the way Slimmer currently works, but thats no worse than it was previously.

![guide](https://cloud.githubusercontent.com/assets/63201/16237938/7558794a-37d6-11e6-99bc-c9d7ae0058c2.png)
