### PR TITLE
Return 404 error for unknown components

### DIFF
--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -2,7 +2,7 @@ require 'component'
 
 class ComponentsController < ApplicationController
   def show
-    @component = Component.get(params[:id])
+    @component = Component.get(params[:id]) || not_found
   end
 
   def index
@@ -10,7 +10,11 @@ class ComponentsController < ApplicationController
   end
 
   def preview
-    @component = Component.get(params[:component_id])
+    @component = Component.get(params[:component_id]) || not_found
     render layout: 'preview'
+  end
+
+  def not_found
+    render status: 404, text: "404 error"
   end
 end


### PR DESCRIPTION
At the moment, there is no error checking when requesting components from the component guide. Therefore, if an unknown component is requested, the user sees the default Rails 500 error page rather than the more appropriate, branded 404 error.

This fix carries out error checking when requesting a component, and returns a 404 error page when the requested component is not found.