### PR TITLE
Return 404 error for unknown components

### DIFF
--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -3,6 +3,7 @@ require 'component'
 class ComponentsController < ApplicationController
   def show
     @component = Component.get(params[:id])
+    head :not_found if @component.nil?
   end
 
   def index
@@ -11,6 +12,10 @@ class ComponentsController < ApplicationController
 
   def preview
     @component = Component.get(params[:component_id])
-    render layout: 'preview'
+    if @component.nil?
+      head :not_found
+    else
+      render layout: 'preview'
+    end
   end
 end

--- a/app/controllers/fixtures_controller.rb
+++ b/app/controllers/fixtures_controller.rb
@@ -5,6 +5,7 @@ class FixturesController < ApplicationController
     @fixture = component.fixtures.find {|f|
       f.id == params[:id]
     }
+    head :not_found if @fixture.nil?
   end
 
   def index
@@ -15,7 +16,11 @@ class FixturesController < ApplicationController
     @fixture = component.fixtures.find {|f|
       f.id == params[:fixture_id]
     }
-    render layout: 'preview'
+    if @fixture.nil?
+      head :not_found
+    else
+      render layout: 'preview'
+    end
   end
 
 private

--- a/test/controllers/components_controller_test.rb
+++ b/test/controllers/components_controller_test.rb
@@ -10,4 +10,10 @@ class ComponentsControllerTest < ActionController::TestCase
     get :show, id: 'title'
     assert_response :success
   end
+
+  test "should fail to get show" do
+    # This component does not exist and should return a 404 error
+    get :show, id: 'test'
+    assert_response :missing
+  end
 end

--- a/test/controllers/fixtures_controller_test.rb
+++ b/test/controllers/fixtures_controller_test.rb
@@ -10,4 +10,10 @@ class FixturesControllerTest < ActionController::TestCase
     get :show, component_id: 'title', id: 'default'
     assert_response :success
   end
+
+  test "should fail to get show" do
+    # This fixture does not exist and should return a 404 error
+    get :show, component_id: 'title', id: 'test'
+    assert_response :missing
+  end
 end


### PR DESCRIPTION
At the moment, there is no error checking when requesting components from the component guide. Therefore, if an unknown component is requested, the user sees the default Rails 500 error page rather than the more appropriate, branded 404 error.

This fix carries out error checking when requesting a component, and returns a 404 error page when the requested component is not found.