### PR TITLE
Update example styles to match Elements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ script:
   # Tests depend on an instance of `static` running, this needs to be stubbed
   # out at some point, in the mean time hit production :(
   - bundle exec rake test
-  - bundle exec govuk-lint-ruby
+  - bundle exec govuk-lint-ruby app test config lib
   - bundle exec govuk-lint-sass app

--- a/Gemfile
+++ b/Gemfile
@@ -37,5 +37,5 @@ group :development do
 end
 
 group :development, :test do
-  gem 'govuk-lint', '0.7.0'
+  gem 'govuk-lint', '2.1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,9 +37,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.3)
-    ast (2.2.0)
-    astrolabe (1.3.1)
-      parser (~> 2.2)
+    ast (2.3.0)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -56,9 +54,9 @@ GEM
     execjs (2.6.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
-    govuk-lint (0.7.0)
-      rubocop (~> 0.35.0)
-      scss_lint (~> 0.44.0)
+    govuk-lint (2.1.0)
+      rubocop (~> 0.43.0)
+      scss_lint
     govuk_frontend_toolkit (4.10.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -83,7 +81,7 @@ GEM
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     null_logger (0.0.1)
-    parser (2.3.0.6)
+    parser (2.4.0.0)
       ast (~> 2.2)
     plek (1.12.0)
     powerpack (0.1.1)
@@ -119,7 +117,8 @@ GEM
       activesupport (= 4.2.4)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.1.0)
+    rainbow (2.2.2)
+      rake
     rake (10.5.0)
     rdoc (4.2.2)
       json (~> 1.4)
@@ -127,14 +126,13 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    rubocop (0.35.1)
-      astrolabe (~> 1.3)
-      parser (>= 2.2.3.0, < 3.0)
+    rubocop (0.43.0)
+      parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
-      tins (<= 1.6.0)
-    ruby-progressbar (1.7.5)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     sass (3.4.21)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -142,9 +140,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scss_lint (0.44.0)
-      rake (~> 10.0)
-      sass (~> 3.4.15)
+    scss_lint (0.53.0)
+      rake (>= 0.9, < 13)
+      sass (~> 3.4.20)
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
@@ -168,7 +166,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
-    tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -177,6 +174,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
+    unicode-display_width (1.2.1)
 
 PLATFORMS
   ruby
@@ -184,7 +182,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
-  govuk-lint (= 0.7.0)
+  govuk-lint (= 2.1.0)
   govuk_frontend_toolkit (= 4.10.0)
   jbuilder (~> 2.0)
   kramdown (= 1.5)
@@ -198,5 +196,8 @@ DEPENDENCIES
   spring
   uglifier (>= 1.3.0)
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.14.5

--- a/app/assets/stylesheets/_component.scss
+++ b/app/assets/stylesheets/_component.scss
@@ -19,11 +19,20 @@
   }
 
   .component-guide-preview {
-    @extend %outdent-to-full-width;
-    padding: $gutter;
+    padding: ($gutter * 1.5) $gutter $gutter;
+    border: 1px solid $border-colour;
+    position: relative;
 
-    box-shadow: 0 0 10px $border-color inset;
-    outline: 1px solid $border-color;
+    &:before {
+      @include core-14;
+      content: "EXAMPLE";
+      position: absolute;
+      top: 0;
+      left: 0;
+      padding: 0.21053em 0.78947em;
+      background: $border-colour;
+      color: $white;
+    }
 
     div[class^="govuk-"] {
       &:hover {

--- a/app/controllers/fixtures_controller.rb
+++ b/app/controllers/fixtures_controller.rb
@@ -2,7 +2,7 @@ require 'component'
 
 class FixturesController < ApplicationController
   def show
-    @fixture = component.fixtures.find {|f|
+    @fixture = component.fixtures.find { |f|
       f.id == params[:id]
     }
     head :not_found if @fixture.nil?
@@ -13,7 +13,7 @@ class FixturesController < ApplicationController
   end
 
   def preview
-    @fixture = component.fixtures.find {|f|
+    @fixture = component.fixtures.find { |f|
       f.id == params[:fixture_id]
     }
     if @fixture.nil?

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -12,7 +12,7 @@ Component = Struct.new(:id, :name, :description, :body, :fixtures) do
   end
 
   def self.build(component)
-    fixtures = component[:fixtures].map {|id, data|
+    fixtures = component[:fixtures].map { |id, data|
       Fixture.new(id.to_s, data)
     }
     self.new(component[:id], component[:name], component[:description], component[:body], fixtures)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,4 +5,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( preview.css prism.js prism.css )
+Rails.application.config.assets.precompile += %w(preview.css prism.js prism.css)


### PR DESCRIPTION
Use the same example styles as GOV.UK Elements: http://govuk-elements.herokuapp.com/typography/

## Elements
![screen shot 2017-05-23 at 09 28 15](https://cloud.githubusercontent.com/assets/319055/26345239/2f08cf7c-3f9a-11e7-9433-419762d01da3.png)

## Before
![screen shot 2017-05-23 at 09 27 01](https://cloud.githubusercontent.com/assets/319055/26345191/055c7f02-3f9a-11e7-9a70-8200b656e3fa.png)

## After
![screen shot 2017-05-23 at 09 26 42](https://cloud.githubusercontent.com/assets/319055/26345190/052471fc-3f9a-11e7-85fc-4ad7dfce04e7.png)

cc @nickcolley @gemmaleigh 