### PR TITLE
Retire application and redirect users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ env:
 script:
   # Tests depend on an instance of `static` running, this needs to be stubbed
   # out at some point, in the mean time hit production :(
-  - bundle exec rake test
+  # - bundle exec rake test
   - bundle exec govuk-lint-ruby app test config lib
   - bundle exec govuk-lint-sass app

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # GOV.UK Component Guide
 
+**Component guides now live within applications and are generated using the [govuk_publishing_components gem](https://github.com/alphagov/govuk_publishing_components). This application is being retired.**
+
+**A list of all component guides is available here: https://docs.publishing.service.gov.uk/manual/components.html. Static components are listed here: https://govuk-static.herokuapp.com/component-guide/**
+
 [![Build Status](https://travis-ci.org/alphagov/govuk-component-guide.svg)](https://travis-ci.org/alphagov/govuk-component-guide)
 
 A living style guide and documentation for GOV.UK Components &mdash; A new approach to sharing UI patterns between applications without having to duplicate code.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,69 +1,13 @@
 Rails.application.routes.draw do
-  get 'about' => 'about#index'
+  root to: redirect('https://govuk-static.herokuapp.com/component-guide')
 
-  resources :components, only: [:index, :show] do
-    get 'preview'
-    resources :fixtures, only: [:index, :show, :preview] do
-      get 'preview'
-    end
-  end
-
-  # Redirects for legacy URLs
   get 'component', to: redirect("/components")
   get 'component/:id', to: redirect("/components/%{id}")
 
-  # The priority is based upon order of creation: first created -> highest priority.
-  # See how all your routes lay out with "rake routes".
+  get 'components/:component/fixtures/:example/preview', to: redirect('https://govuk-static.herokuapp.com/component-guide/%{component}/%{example}/preview')
+  get 'components/:component/fixtures/:example', to: redirect('https://govuk-static.herokuapp.com/component-guide/%{component}/%{example}')
+  get 'components/:component', to: redirect('https://govuk-static.herokuapp.com/component-guide/%{component}')
 
-  # You can have the root of your site routed with "root"
-  root 'welcome#index'
-
-  # Example of regular route:
-  #   get 'products/:id' => 'catalog#view'
-
-  # Example of named route that can be invoked with purchase_url(id: product.id)
-  #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
-
-  # Example resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Example resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Example resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Example resource route with more complex sub-resources:
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', on: :collection
-  #     end
-  #   end
-
-  # Example resource route with concerns:
-  #   concern :toggleable do
-  #     post 'toggle'
-  #   end
-  #   resources :posts, concerns: :toggleable
-  #   resources :photos, concerns: :toggleable
-
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
+  # Catch all
+  get '*path', to: redirect('https://govuk-static.herokuapp.com/component-guide')
 end


### PR DESCRIPTION
* Redirect all routes to
https://docs.publishing.service.gov.uk/manual/components.html
* Static components now live in a guide at
https://govuk-static.herokuapp.com/component-guide/
* Disable tests which would otherwise fail without routes configured
* Keep changes minimal to keep app in-tact before moving to attic

Part of https://trello.com/c/GtIEFBfC/103-2-retire-govuk-component-guide